### PR TITLE
Add toggleHighlight feature to multi-highlight plugin

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -130,6 +130,25 @@ function freshHighlight() {
 	addHighlight();
 }
 
+function toggleHightlight() {
+	const editor = vscode.window.activeTextEditor;
+	if (!editor) {
+		return;
+	}
+
+	const word = getWordAtCursor();
+	if (!word) {
+		return;
+	}
+
+	const index = highlightWords.findIndex(w => w === word);
+	if (index === -1) {
+		addHighlight();
+	} else {
+		removeHighlightForWord(word);
+	}
+}
+
 export function activate(context: vscode.ExtensionContext) {
 	const config = vscode.workspace.getConfiguration('multi-highlight');
 	const colours = (config.get<string>('colours') || DEFAULT_COLOURS).split(',').map(p => p.trim().split(':').map(c => c.trim()));
@@ -148,6 +167,7 @@ export function activate(context: vscode.ExtensionContext) {
 		vscode.commands.registerCommand('multi-highlight.removeHighlight', () => { removeHighlight(); }),
 		vscode.commands.registerCommand('multi-highlight.clearHighlights', () => { clearHighlights(); }),
 		vscode.commands.registerCommand('multi-highlight.freshHighlight', () => { freshHighlight(); }),
+		vscode.commands.registerCommand('multi-highlight.toggleHighlight', () => { toggleHightlight(); }),
 	];
 
 	commands.forEach(cmd => context.subscriptions.push(cmd));


### PR DESCRIPTION
This pull request introduces a new feature to the multi-highlight plugin, enabling users to toggle highlights conveniently using shortcut keys or vim keymap. The `multi-highlight.toggleHighlight` property is now utilized for this purpose.